### PR TITLE
Add half duplex support

### DIFF
--- a/libloragw/src/loragw_spi.native.c
+++ b/libloragw/src/loragw_spi.native.c
@@ -213,11 +213,16 @@ int lgw_spi_w(void *spi_target, uint8_t spi_mux_mode, uint8_t spi_mux_target, ui
 /* Simple read */
 int lgw_spi_r(void *spi_target, uint8_t spi_mux_mode, uint8_t spi_mux_target, uint8_t address, uint8_t *data) {
     int spi_device;
-    uint8_t out_buf[3];
+    uint8_t out_buf[3]={0};
     uint8_t command_size;
     uint8_t in_buf[ARRAY_SIZE(out_buf)];
+    #ifdef SPI_HALFDUPLEX
+    struct spi_ioc_transfer k[2];
+    int a,i;
+    #else
     struct spi_ioc_transfer k;
     int a;
+    #endif
 
     /* check input variables */
     CHECK_NULL(spi_target);
@@ -236,20 +241,37 @@ int lgw_spi_r(void *spi_target, uint8_t spi_mux_mode, uint8_t spi_mux_target, ui
         command_size = 3;
     } else {
         out_buf[0] = READ_ACCESS | (address & 0x7F);
-        out_buf[1] = 0x00;
-        command_size = 2;
+        #ifdef SPI_HALFDUPLEX
+            command_size = 1;
+        #else
+            out_buf[1] = 0x00;
+            command_size = 2;
+        #endif
     }
 
     /* I/O transaction */
     memset(&k, 0, sizeof(k)); /* clear k */
-    k.tx_buf = (unsigned long) out_buf;
-    k.rx_buf = (unsigned long) in_buf;
-    k.len = command_size;
-    k.cs_change = 0;
-    a = ioctl(spi_device, SPI_IOC_MESSAGE(1), &k);
-
+    #ifdef SPI_HALFDUPLEX
+	    k[0].tx_buf = (unsigned long) out_buf;
+		k[1].rx_buf = (unsigned long) in_buf;
+		k[0].len = command_size;
+		k[1].len = command_size;
+		k[0].cs_change = 0;
+		k[1].cs_change = 1;
+		a = ioctl(spi_device, SPI_IOC_MESSAGE(2), &k);
+    #else
+        k.tx_buf = (unsigned long) out_buf;
+        k.rx_buf = (unsigned long) in_buf;
+        k.len = command_size;
+        k.cs_change = 0;
+        a = ioctl(spi_device, SPI_IOC_MESSAGE(1), &k);
+    #endif
     /* determine return code */
-    if (a != (int)k.len) {
+    #ifdef SPI_HALFDUPLEX
+		if (a != (int)k[1].len + (int)k[0].len) {
+    #else    
+        if (a != (int)k.len) {
+    #endif
         DEBUG_MSG("ERROR: SPI READ FAILURE\n");
         return LGW_SPI_ERROR;
     } else {
@@ -300,7 +322,11 @@ int lgw_spi_wb(void *spi_target, uint8_t spi_mux_mode, uint8_t spi_mux_target, u
     k[0].tx_buf = (unsigned long) &command[0];
     k[0].len = command_size;
     k[0].cs_change = 0;
-    k[1].cs_change = 0;
+    #ifdef SPI_HALFDUPLEX
+        k[1].cs_change = 1;
+    #else
+        k[1].cs_change = 0;
+    #endif
     for (i=0; size_to_do > 0; ++i) {
         chunk_size = (size_to_do < LGW_BURST_CHUNK) ? size_to_do : LGW_BURST_CHUNK;
         offset = i * LGW_BURST_CHUNK;
@@ -362,7 +388,11 @@ int lgw_spi_rb(void *spi_target, uint8_t spi_mux_mode, uint8_t spi_mux_target, u
     k[0].tx_buf = (unsigned long) &command[0];
     k[0].len = command_size;
     k[0].cs_change = 0;
-    k[1].cs_change = 0;
+    #ifdef SPI_HALFDUPLEX
+        k[1].cs_change = 1;
+    #else
+        k[1].cs_change = 0;
+    #endif
     for (i=0; size_to_do > 0; ++i) {
         chunk_size = (size_to_do < LGW_BURST_CHUNK) ? size_to_do : LGW_BURST_CHUNK;
         offset = i * LGW_BURST_CHUNK;


### PR DESCRIPTION
Allows the native spi to work in a half duplex mode. Good for socs that have silicon bugs.