### PR TITLE
Added additional fpga versions

### DIFF
--- a/libloragw/src/loragw_reg.c
+++ b/libloragw/src/loragw_reg.c
@@ -48,7 +48,7 @@ Maintainer: Sylvain Miermont
 #define PAGE_ADDR        0x00
 #define PAGE_MASK        0x03
 
-const uint8_t FPGA_VERSION[] = { 31, 33 }; /* several versions could be supported */
+const uint8_t FPGA_VERSION[] = {28, 31, 33, 35}; /* several versions could be supported */
 
 /*
 auto generated register mapping for C code : 11-Jul-2013 13:20:40


### PR DESCRIPTION
Some boards use different fpga versions that are not included in the default reg file